### PR TITLE
fix(markdown-to-adf): preserve links and render tables in descriptions/comments

### DIFF
--- a/__tests__/markdown-to-adf.test.ts
+++ b/__tests__/markdown-to-adf.test.ts
@@ -474,5 +474,84 @@ Por favor, @[6418727f9d6383e32a3261b0:Reynier Rivero], confirma que las mencione
         marks: [{ type: 'strike' }, { type: 'strong' }, { type: 'em' }]
       });
     });
+
+    test('should convert inline link [text](url) to a link mark', () => {
+      const markdown = 'See [PR #117](https://github.com/AvantoDev/ai-python-agentic-ocr/pull/117) please';
+      const result = markdownToADF(markdown) as TestADFDocument;
+      const paragraph = result.content[0] as TestADFParagraph;
+
+      expect(paragraph.content).toContainEqual({
+        type: 'text',
+        text: 'PR #117',
+        marks: [
+          {
+            type: 'link',
+            attrs: { href: 'https://github.com/AvantoDev/ai-python-agentic-ocr/pull/117' }
+          }
+        ]
+      });
+    });
+
+    test('should convert an autolink <url> to a link mark', () => {
+      const markdown = '<https://example.com/foo>';
+      const result = markdownToADF(markdown) as TestADFDocument;
+      const paragraph = result.content[0] as TestADFParagraph;
+
+      expect(paragraph.content).toContainEqual({
+        type: 'text',
+        text: 'https://example.com/foo',
+        marks: [{ type: 'link', attrs: { href: 'https://example.com/foo' } }]
+      });
+    });
+
+    test('should keep the link title when present', () => {
+      const markdown = '[docs](https://example.com "Docs Home")';
+      const result = markdownToADF(markdown) as TestADFDocument;
+      const paragraph = result.content[0] as TestADFParagraph;
+
+      expect(paragraph.content).toContainEqual({
+        type: 'text',
+        text: 'docs',
+        marks: [
+          {
+            type: 'link',
+            attrs: { href: 'https://example.com', title: 'Docs Home' }
+          }
+        ]
+      });
+    });
+
+    test('should preserve a link inside a list item', () => {
+      const markdown = '- FE PR: [#382](https://github.com/AvantoDev/front-react-strata-ui/pull/382)';
+      const result = markdownToADF(markdown) as TestADFDocument;
+      const bulletList = result.content[0] as TestADFBulletList;
+      const itemContent = bulletList.content[0].content[0].content;
+
+      expect(itemContent).toContainEqual({
+        type: 'text',
+        text: '#382',
+        marks: [
+          {
+            type: 'link',
+            attrs: { href: 'https://github.com/AvantoDev/front-react-strata-ui/pull/382' }
+          }
+        ]
+      });
+    });
+
+    test('should keep a bold word inside a link with both marks', () => {
+      const markdown = '[**bold** link](https://example.com)';
+      const result = markdownToADF(markdown) as TestADFDocument;
+      const paragraph = result.content[0] as TestADFParagraph;
+
+      expect(paragraph.content).toContainEqual({
+        type: 'text',
+        text: 'bold',
+        marks: [
+          { type: 'strong' },
+          { type: 'link', attrs: { href: 'https://example.com' } }
+        ]
+      });
+    });
   });
 });

--- a/__tests__/markdown-to-adf.test.ts
+++ b/__tests__/markdown-to-adf.test.ts
@@ -553,5 +553,79 @@ Por favor, @[6418727f9d6383e32a3261b0:Reynier Rivero], confirma que las mencione
         ]
       });
     });
+
+    test('should convert a markdown table to an ADF table', () => {
+      const markdown = [
+        '| Name | Status |',
+        '|------|--------|',
+        '| PR   | Open   |',
+        '| CI   | Green  |'
+      ].join('\n');
+
+      const result = markdownToADF(markdown) as TestADFDocument;
+
+      const table = result.content[0] as {
+        type: string;
+        attrs?: Record<string, unknown>;
+        content: Array<{
+          type: string;
+          content: Array<{
+            type: string;
+            content: Array<{ type: string; content: TestADFTextNode[] }>;
+          }>;
+        }>;
+      };
+
+      expect(table.type).toBe('table');
+      expect(table.attrs).toEqual({ isNumberColumnEnabled: false, layout: 'default' });
+      // 1 header row + 2 data rows
+      expect(table.content).toHaveLength(3);
+
+      // Header row uses tableHeader cells
+      const headerRow = table.content[0];
+      expect(headerRow.type).toBe('tableRow');
+      expect(headerRow.content.map(c => c.type)).toEqual(['tableHeader', 'tableHeader']);
+      expect(headerRow.content[0].content[0]).toEqual({
+        type: 'paragraph',
+        content: [{ type: 'text', text: 'Name' }]
+      });
+
+      // Data row uses tableCell cells
+      const firstDataRow = table.content[1];
+      expect(firstDataRow.content.map(c => c.type)).toEqual(['tableCell', 'tableCell']);
+      expect(firstDataRow.content[1].content[0]).toEqual({
+        type: 'paragraph',
+        content: [{ type: 'text', text: 'Open' }]
+      });
+    });
+
+    test('should preserve inline formatting and links inside table cells', () => {
+      const markdown = [
+        '| Item | Link |',
+        '|------|------|',
+        '| **bold** | [PR](https://example.com/pr) |'
+      ].join('\n');
+
+      const result = markdownToADF(markdown) as TestADFDocument;
+      const table = result.content[0] as {
+        content: Array<{
+          content: Array<{ content: Array<{ content: TestADFTextNode[] }> }>;
+        }>;
+      };
+
+      const dataRow = table.content[1];
+      // bold cell
+      expect(dataRow.content[0].content[0].content).toContainEqual({
+        type: 'text',
+        text: 'bold',
+        marks: [{ type: 'strong' }]
+      });
+      // link cell
+      expect(dataRow.content[1].content[0].content).toContainEqual({
+        type: 'text',
+        text: 'PR',
+        marks: [{ type: 'link', attrs: { href: 'https://example.com/pr' } }]
+      });
+    });
   });
 });

--- a/src/utils/markdown-to-adf.ts
+++ b/src/utils/markdown-to-adf.ts
@@ -492,7 +492,7 @@ export class MarkdownToADFConverter {
       // Apply formatting to all text nodes
       return nodes.map(node => {
         if (node.type === 'text') {
-          return this.applyFormatting(node, token.type);
+          return this.applyFormatting(node, token);
         }
         return node;
       });
@@ -551,17 +551,22 @@ export class MarkdownToADFConverter {
   }
 
   /**
-   * Applies formatting to a text node
+   * Applies a mark to a text node based on the inline token type.
+   *
+   * Handles links (and code spans) in addition to the basic text styles so
+   * that nested inline tokens — e.g. `[text](url)`, autolinks `<url>`, GFM
+   * bare URLs, or a bold word inside a link — keep their `link` mark (with
+   * `href`/`title`) instead of being flattened to plain text.
    */
-  private applyFormatting(node: ADFNode, formatType: string): ADFNode {
+  private applyFormatting(node: ADFNode, token: GenericToken): ADFNode {
     if (node.type !== 'text') {
       return node;
     }
 
     const existingMarks = node.marks || [];
-    let newMark;
+    let newMark: ADFMark;
 
-    switch (formatType) {
+    switch (token.type) {
       case 'strong':
         newMark = { type: 'strong' };
         break;
@@ -571,8 +576,24 @@ export class MarkdownToADFConverter {
       case 'del':
         newMark = { type: 'strike' };
         break;
+      case 'codespan':
+        newMark = { type: 'code' };
+        break;
+      case 'link':
+        newMark = {
+          type: 'link',
+          attrs: token.title
+            ? { href: token.href || '', title: token.title }
+            : { href: token.href || '' }
+        };
+        break;
       default:
         return node;
+    }
+
+    // Avoid stacking a duplicate mark of the same type.
+    if (existingMarks.some(mark => mark.type === newMark.type)) {
+      return node;
     }
 
     return {

--- a/src/utils/markdown-to-adf.ts
+++ b/src/utils/markdown-to-adf.ts
@@ -28,9 +28,9 @@ interface GenericToken {
   start?: number;
   items?: GenericToken[];
   lang?: string;
-  header?: string[];
-  align?: string[];
-  cells?: string[][];
+  header?: GenericToken[];
+  align?: (string | null)[];
+  rows?: GenericToken[][];
   [key: string]: unknown;
 }
 
@@ -411,57 +411,56 @@ export class MarkdownToADFConverter {
   }
 
   /**
-   * Converts a table token to ADF table node
+   * Converts a table token to ADF table node.
+   *
+   * marked >= 12 emits the header as an array of cell objects (`{ text, tokens }`)
+   * and the body as `rows` (array of rows of cell objects) — the legacy
+   * `header: string[]` / `cells: string[][]` shape no longer exists. Reading the
+   * old shape produced an empty/invalid table that Jira rejected, so tables
+   * could not be sent at all. We now read header/rows and render each cell's
+   * inline tokens, so formatting and links inside cells are preserved.
    */
   private convertTable(token: GenericToken): ADFNode {
     const content: ADFNode[] = [];
 
-    if (token.header && token.cells) {
-      // Add header row
-      const headerRow: ADFNode = {
-        type: 'tableRow',
-        content: token.header.map(cell => ({
-          type: 'tableHeader',
-          content: [
-            {
-              type: 'paragraph',
-              content: [
-                {
-                  type: 'text',
-                  text: cell
-                }
-              ]
-            }
-          ]
-        }))
-      };
-      content.push(headerRow);
+    const buildCellContent = (cell: GenericToken): ADFNode[] => {
+      const inline: ADFNode[] = [];
+      if (cell.tokens && cell.tokens.length > 0) {
+        for (const inlineToken of cell.tokens) {
+          inline.push(...this.convertInlineToken(inlineToken));
+        }
+      } else if (cell.text) {
+        inline.push({ type: 'text', text: cell.text });
+      }
+      // A table cell must contain at least one block node; an empty paragraph is valid.
+      return [{ type: 'paragraph', content: inline }];
+    };
 
-      // Add data rows
-      for (const row of token.cells) {
-        const tableRow: ADFNode = {
-          type: 'tableRow',
-          content: row.map(cell => ({
-            type: 'tableCell',
-            content: [
-              {
-                type: 'paragraph',
-                content: [
-                  {
-                    type: 'text',
-                    text: cell
-                  }
-                ]
-              }
-            ]
-          }))
-        };
-        content.push(tableRow);
+    const buildRow = (cells: GenericToken[], isHeader: boolean): ADFNode => ({
+      type: 'tableRow',
+      content: cells.map(cell => ({
+        type: isHeader ? 'tableHeader' : 'tableCell',
+        attrs: {},
+        content: buildCellContent(cell)
+      }))
+    });
+
+    if (token.header && token.header.length > 0) {
+      content.push(buildRow(token.header, true));
+    }
+
+    if (token.rows && token.rows.length > 0) {
+      for (const row of token.rows) {
+        content.push(buildRow(row, false));
       }
     }
 
     return {
       type: 'table',
+      attrs: {
+        isNumberColumnEnabled: false,
+        layout: 'default'
+      },
       content: content
     };
   }


### PR DESCRIPTION
Fixes two cases where rich Markdown was silently dropped or rejected when converting to ADF for Jira **descriptions and comments**.

## 1. Links were dropped
Every link form rendered as plain, non-clickable text: `[text](url)`, autolinks `<url>`, GFM bare URLs, and links inside list items.

**Root cause:** `marked` emits an inline `link` token with its label as **child tokens**, so conversion always took the nested-tokens branch in `convertInlineToken`, which called `applyFormatting(node, token.type)`. That helper only handled `strong`/`em`/`del` and fell through to `default → return node` for `link` (and `codespan`), so the `link` mark — and the `href` — was never applied. The standalone `case 'link'` in the switch was effectively dead code because link tokens always have child tokens.

**Fix:** `applyFormatting` now takes the full token and applies a proper `link` mark (with `href`/optional `title`) plus `code` for code spans, with same-type de-duplication. Nested formatting is preserved (e.g. a **bold** word inside a link keeps both marks).

## 2. Tables could not be sent
`convertTable` read the legacy `token.header: string[]` / `token.cells: string[][]` shape, but **marked >= 12** emits `header` as an array of cell objects (`{ text, tokens }`) and the body as `rows`. With `cells` undefined the table body came out empty and the header cells stringified, producing invalid ADF that Jira rejected — so tables couldn't be sent at all.

**Fix:** `convertTable` now reads `header`/`rows`, renders each cell's inline tokens (so formatting and links **inside cells** are preserved), emits `tableHeader`/`tableCell` with a paragraph block per cell, and sets the `table` attrs (`isNumberColumnEnabled`, `layout`) Jira expects.

## Tests
Added cases for inline links, autolinks, link titles, links in list items, bold-inside-link, a basic table, and inline formatting/links inside table cells. Full suite green (**19/19**), `npm run lint` and `npm run build` clean. Existing expectations unchanged — no regression.

## Notes
- No public API change; purely fixes the ADF output.
- Did not touch `CHANGELOG.md` / version (left to the maintainer's `publish.sh` flow).